### PR TITLE
Added constructors for `Transaction`

### DIFF
--- a/src/buzzcoin/core/LedgerBlock.java
+++ b/src/buzzcoin/core/LedgerBlock.java
@@ -2,12 +2,29 @@ package buzzcoin.core;
 
 public class LedgerBlock {
 	
-	
-	
+	// LedgerBlock is 64 transactions
+	private Transaction[] transactionBlock;
+	private int filled;
+
+
 	public LedgerBlock() {
-		
+		transactionBlock = new Transaction[64];
+		filled = 0;
+	}
+	
+	public LedgerBlock(Transaction[] transactionBlock, int filled) throws Exception {
+		if (transactionBlock.length > 64)
+			throw new Exception("transactionBlock length must be at most 64 transactions");
+		if (filled > 64)
+			throw new Exception("filled must be at most 64");
+		this.transactionBlock = transactionBlock;
+	}
+
+	public void append(Transaction transaction) {
+	    transactionBlock[filled] = transaction;
+	    ++filled;
 	}
 	
 	
-	
 }
+

--- a/src/buzzcoin/core/Transaction.java
+++ b/src/buzzcoin/core/Transaction.java
@@ -1,15 +1,39 @@
 package buzzcoin.core;
 
+import java.util.Arrays;
+
 public class Transaction {
-	
-	// transaction size = sender + receipient + amnt + transId + sig
-	//					   2048		2048		 64		64		  256 = 4480 bits = 560 bytes
-	public Transaction(byte[] data) {
-		
-	}
-	
-	public Transaction(byte[] sender, byte[] receip, byte[] amnt, byte[] transId, byte[] sig) {
-		
-	}
-	
+    // transaction size = sender + receipient + amnt + transId + sig
+    //					   2048		2048		 64		64		  256 = 4480 bits = 560 bytes
+    private byte[] data;
+
+    public Transaction(byte[] data) throws Exception {
+        if (data.length != 560)
+            throw new Exception("data must be 560 bytes");
+        this.data = data;
+    }
+
+    public Transaction(byte[] sender, byte[] recipient, byte[] amount, byte[] transactionId, byte[] signature) throws Exception {
+        if (sender.length != 256)
+            throw new Exception("sender must be 256 bytes");
+        if (recipient.length != 256)
+            throw new Exception("recipient must be 256 bytes");
+        if (amount.length != 8) throw new Exception("amount must be 8 bytes");
+        if (transactionId.length != 8)
+            throw new Exception("transaction id must be 8 bytes");
+        if (signature.length != 32)
+            throw new Exception("signature must be 32 bytes");
+
+        // TODO: Fix this awful line
+        this.data = concat(sender, concat(recipient, concat(amount, concat(transactionId, signature))));
+
+    }
+
+    public static byte[] concat(byte[] a, byte[] b) {
+        int lenA = a.length;
+        int lenB = b.length;
+        byte[] c = Arrays.copyOf(a, lenA + lenB);
+        System.arraycopy(b, 0, c, lenA, lenB);
+        return c;
+    }
 }

--- a/src/buzzcoin/miner/Miner.java
+++ b/src/buzzcoin/miner/Miner.java
@@ -3,7 +3,6 @@ package buzzcoin.miner;
 public class Miner {
 	
 	public Miner() {
-		
 	}
 	
 	


### PR DESCRIPTION
One constructor takes in 560 bytes of data as a whole, while the other takes each chunk of data separately.
One possible issue with this commit is that the `Transaction.concat()` method only works with two inputs, leading to a cons-list-like method structure. This is ugly and needs to be refactored, but it works for now.